### PR TITLE
Add support for local Brother QL printers

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,16 @@ Open your browser and navigate to [http://localhost:5000](http://localhost:5000)
 
 3. Access the application at [http://localhost:5000](http://localhost:5000)
 
+## Configuration
+
+The application settings can be configured in the `data/settings.json` file. This file contains various options for printer settings, including:
+
+- `printer_uri`: The URI of the printer to use (e.g., `tcp://192.168.1.100` when over network, or `file:///dev/usb/lp0` when using USB)
+- `printer_model`: The model of the printer (e.g., `QL-800`)
+- `label_size`: The size of the label to print (e.g., `62`)
+- `keep_alive_enabled`: Whether to keep the printer connection alive (only needed for network printers)
+- `keep_alive_interval`: The interval for keep-alive messages (in seconds)
+
 ## 📔 API Documentation
 
 The API is fully documented using OpenAPI/Swagger. You can access the interactive documentation at [http://localhost:5000/api/v1/ui/](http://localhost:5000/api/v1/ui/) when the application is running.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: dodoooh/brother_ql_app:dev
     container_name: brother_ql_app
     ports:
-      - "5055:5000"
+      - "5000:5000"
     volumes:
       - ./data:/app/data
       - ./uploads:/app/uploads

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -359,7 +359,7 @@
                                                 <option value="false">Disabled</option>
                                                 <option value="true">Enabled</option>
                                             </select>
-                                            <div class="form-text">Prevents printer from shutting down</div>
+                                            <div class="form-text">Prevents printer from shutting down (only needed for network printers)</div>
                                         </div>
                                         <div class="col-md-6">
                                             <label for="keep-alive-interval" class="form-label">Interval (seconds)</label>


### PR DESCRIPTION
I was looking for an actively maintained Brother QL printer GUI project and this seems to be the best one. However, what is missing for my usecase is support for non-network QL printer. Hence, this PR adds support for directly attached (via USB) Brother printers.

So far, only network printers were supported, however, many printer models (e.g. QL-800 or QL-1100) do not have (and don't need) networking. They use an USB interface.

As keep-alive is not meaningful in the context of a directly attached printer, it is disabled/prevented if a local printer URI is selected.

---

Depending on what the policy for external contributions are, I may submit additional features over time.