### PR TITLE
Switch to brother-ql-inventree

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pydantic==2.4.2
 flask-cors==4.0.0
 
 # Printer communication
-brother-ql==0.9.4
+brother-ql-inventree==1.3
 Pillow==10.0.1
 pysnmp==4.4.12
 qrcode==7.4.2 

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -372,7 +372,7 @@ components:
           description: Model of the Brother QL printer (e.g., QL-800, QL-810W, QL-820NWB)
           example: "QL-800"
           default: "QL-800"
-          enum: ["QL-500", "QL-550", "QL-560", "QL-570", "QL-580N", "QL-650TD", "QL-700", "QL-710W", "QL-720NW", "QL-800", "QL-810W", "QL-820NWB", "QL-1050", "QL-1060N"]
+          enum: ["QL-500", "QL-550", "QL-560", "QL-570", "QL-580N", "QL-650TD", "QL-700", "QL-710W", "QL-720NW", "QL-800", "QL-810W", "QL-820NWB", "QL-1050", "QL-1060N", "QL-1100", "QL-1100NWB", "QL-1115NWB"]
       required:
         - printer_uri
         - printer_model
@@ -580,13 +580,13 @@ components:
           description: Model of the Brother QL printer
           example: "QL-800"
           default: "QL-800"
-          enum: ["QL-500", "QL-550", "QL-560", "QL-570", "QL-580N", "QL-650TD", "QL-700", "QL-710W", "QL-720NW", "QL-800", "QL-810W", "QL-820NWB", "QL-1050", "QL-1060N"]
+          enum: ["QL-500", "QL-550", "QL-560", "QL-570", "QL-580N", "QL-650TD", "QL-700", "QL-710W", "QL-720NW", "QL-800", "QL-810W", "QL-820NWB", "QL-1050", "QL-1060N", "QL-1100", "QL-1100NWB", "QL-1115NWB"]
         label_size:
           type: string
           description: Size of the label
           example: "62"
           default: "62"
-          enum: ["12", "29", "38", "50", "54", "62", "102", "17x54", "17x87", "23x23", "29x42", "29x90", "39x90", "39x48", "52x29", "62x29", "62x100", "102x51", "102x152", "d12", "d24", "d58"]
+          enum: ["12", "12+17", "18", "29", "38", "50", "54", "62", "62red", "102", "103", "104", "17x54", "17x87", "23x23", "29x42", "29x90", "39x90", "39x48", "52x29", "54x29", "60x86", "62x29", "62x100", "102x51", "102x152", "103x164", "d12", "d24", "d58", "pt12", "pt18", "pt24", "pt36"]
         rotate:
           type: integer
           description: Rotation angle in degrees
@@ -634,13 +634,13 @@ components:
           description: Default printer model
           example: "QL-800"
           default: "QL-800"
-          enum: ["QL-500", "QL-550", "QL-560", "QL-570", "QL-580N", "QL-650TD", "QL-700", "QL-710W", "QL-720NW", "QL-800", "QL-810W", "QL-820NWB", "QL-1050", "QL-1060N"]
+          enum: ["QL-500", "QL-550", "QL-560", "QL-570", "QL-580N", "QL-650TD", "QL-700", "QL-710W", "QL-720NW", "QL-800", "QL-810W", "QL-820NWB", "QL-1050", "QL-1060N", "QL-1100", "QL-1100NWB", "QL-1115NWB"]
         label_size:
           type: string
           description: Default label size
           example: "62"
           default: "62"
-          enum: ["12", "29", "38", "50", "54", "62", "102", "17x54", "17x87", "23x23", "29x42", "29x90", "39x90", "39x48", "52x29", "62x29", "62x100", "102x51", "102x152", "d12", "d24", "d58"]
+          enum: ["12", "12+17", "18", "29", "38", "50", "54", "62", "62red", "102", "103", "104", "17x54", "17x87", "23x23", "29x42", "29x90", "39x90", "39x48", "52x29", "54x29", "60x86", "62x29", "62x100", "102x51", "102x152", "103x164", "d12", "d24", "d58", "pt12", "pt18", "pt24", "pt36"]
         font_size:
           type: integer
           description: Default font size

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -306,7 +306,25 @@
                                             <label for="printer-model" class="form-label">Printer Model</label>
                                             <div class="input-group">
                                                 <span class="input-group-text"><i class="bi bi-printer"></i></span>
-                                                <input type="text" id="printer-model" class="form-control" placeholder="QL-800">
+                                                <select id="printer-model" class="form-select">
+                                                    <option value="QL-500">QL-500</option>
+                                                    <option value="QL-550">QL-550</option>
+                                                    <option value="QL-560">QL-560</option>
+                                                    <option value="QL-570">QL-570</option>
+                                                    <option value="QL-580N">QL-580N</option>
+                                                    <option value="QL-650TD">QL-650TD</option>
+                                                    <option value="QL-700">QL-700</option>
+                                                    <option value="QL-710W">QL-710W</option>
+                                                    <option value="QL-720NW">QL-720NW</option>
+                                                    <option value="QL-800">QL-800</option>
+                                                    <option value="QL-810W">QL-810W</option>
+                                                    <option value="QL-820NWB">QL-820NWB</option>
+                                                    <option value="QL-1050">QL-1050</option>
+                                                    <option value="QL-1060N">QL-1060N</option>
+                                                    <option value="QL-1100">QL-1100</option>
+                                                    <option value="QL-1100NWB">QL-1100NWB</option>
+                                                    <option value="QL-1115NWB">QL-1115NWB</option>
+                                                </select>
                                             </div>
                                         </div>
                                     </div>

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -331,11 +331,42 @@
                                     
                                     <div class="row mb-3">
                                         <div class="col-md-6">
-                                            <label for="label-size" class="form-label">Label Size</label>
+                                            <label for="label-size" class="form-label">Label Type</label>
                                             <select id="label-size" class="form-select">
-                                                <option value="62">62 mm</option>
-                                                <option value="29">29 mm</option>
-                                                <option value="12">12 mm</option>
+                                                <option value="12">12 mm (endless)</option>
+                                                <option value="12+17">12+17 mm (endless)</option>
+                                                <option value="18">18 mm (endless)</option>
+                                                <option value="29">29 mm (endless)</option>
+                                                <option value="38">38 mm (endless)</option>
+                                                <option value="50">50 mm (endless)</option>
+                                                <option value="54">54 mm (endless)</option>
+                                                <option value="62">62 mm (endless)</option>
+                                                <option value="62red">62 mm (red, endless)</option>
+                                                <option value="102">102 mm (endless)</option>
+                                                <option value="103">103 mm (endless)</option>
+                                                <option value="104">104 mm (endless)</option>
+                                                <option value="17x54">17x54 mm (die-cut)</option>
+                                                <option value="17x87">17x87 mm (die-cut)</option>
+                                                <option value="23x23">23x23 mm (die-cut)</option>
+                                                <option value="29x42">29x42 mm (die-cut)</option>
+                                                <option value="29x90">29x90 mm (die-cut)</option>
+                                                <option value="39x90">39x90 mm (die-cut)</option>
+                                                <option value="39x48">39x48 mm (die-cut)</option>
+                                                <option value="52x29">52x29 mm (die-cut)</option>
+                                                <option value="54x29">54x29 mm (die-cut)</option>
+                                                <option value="60x86">60x86 mm (die-cut)</option>
+                                                <option value="62x29">62x29 mm (die-cut)</option>
+                                                <option value="62x100">62x100 mm (die-cut)</option>
+                                                <option value="102x51">102x51 mm (die-cut)</option>
+                                                <option value="102x152">102x152 mm (die-cut)</option>
+                                                <option value="103x164">103x164 mm (die-cut)</option>
+                                                <option value="d12">12mm (round die-cut)</option>
+                                                <option value="d24">24mm (round die-cut)</option>
+                                                <option value="d58">58mm (round die-cut)</option>
+                                                <option value="pt12">pTouch 12mm (endless)</option>
+                                                <option value="pt18">pTouch 18mm (endless)</option>
+                                                <option value="pt24">pTouch 24mm (endless)</option>
+                                                <option value="pt36">pTouch 36mm (endless)</option>
                                             </select>
                                         </div>
                                         <div class="col-md-6">


### PR DESCRIPTION
Switching from [`brother-ql`](https://github.com/matmair/brother_ql-inventree) who received its last update > 5 years ago to [`brother-ql-inventree`](https://github.com/matmair/brother_ql-inventree) which seems to be reasonably well maintained. The main motivation for doing this is that this adds support for the printers
- QL-1100,
- QL-1100NWB, and
- QL-1115NWB

as well as added label sizes
- 12+17 (12mm endless)
- 18 (18mm endless)
- 103 (104mm endless)
- 54x29 (54mm x 29mm die-cut)
- 60x86 (60mm x 87mm die-cut)
- 103x164 (104mm x 164mm die-cut)
- as well as a few pTouch endless labels (pt12, pt18, pt24, pt36)

This is reflected by updated in the UI. I made the printer model a dropdown as the API will not accept any other values, anyway, as this property is of type `enum`:

<img width="577" height="999" alt="image" src="https://github.com/user-attachments/assets/97a4dbb8-4058-4191-8043-bb43b4123494" />

<img width="577" height="1086" alt="image" src="https://github.com/user-attachments/assets/0bb8df74-4003-40b7-a5ec-95810e5fa7a8" />
