### PR TITLE
Use the loaded roll's printable width instead of a hardcoded 696px

### DIFF
--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -115,6 +115,36 @@ paths:
         '500':
           $ref: '#/components/responses/InternalServerError'
 
+  /text/preview:
+    post:
+      summary: Render a text label without printing
+      description: >
+        Returns the exact PNG that would be sent to the printer, so a client can
+        show a true preview instead of approximating the layout in HTML/CSS.
+      operationId: api.text_controller.preview_text
+      tags:
+        - text
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TextPrintRequest'
+      responses:
+        '200':
+          description: Rendered label image
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+        '400':
+          description: Invalid request
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /text/print:
     post:
       summary: Print text on a label

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -129,7 +129,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/TextPrintRequest'
+              $ref: '#/components/schemas/TextPreviewRequest'
       responses:
         '200':
           description: Rendered label image
@@ -437,6 +437,37 @@ components:
         - text
         - settings
         
+    TextPreviewRequest:
+      type: object
+      description: >
+        Same shape as TextPrintRequest but without printer requirements --
+        rendering only needs the label geometry, so a preview can be produced
+        before a printer is configured.
+      properties:
+        text:
+          type: string
+          description: Text to render, can include HTML formatting
+          example: "<b>Hello World!</b>"
+        settings:
+          type: object
+          properties:
+            label_size:
+              type: string
+              description: Label identifier, e.g. "62" or "29x62"
+              default: "62"
+            font_size:
+              type: integer
+              default: 50
+            alignment:
+              type: string
+              enum: [left, center, right]
+              default: left
+            rotate:
+              type: integer
+              default: 0
+      required:
+        - text
+
     TextQRCodeLabelRequest:
       type: object
       properties:

--- a/src/api/openapi.yaml
+++ b/src/api/openapi.yaml
@@ -465,6 +465,12 @@ components:
             rotate:
               type: integer
               default: 0
+            auto_fit:
+              type: boolean
+              description: >
+                Shrink the font until the text fits a die-cut label's fixed
+                height. Ignored on continuous tape, which simply grows.
+              default: true
       required:
         - text
 
@@ -648,6 +654,12 @@ components:
           example: "62"
           default: "62"
           enum: ["12", "12+17", "18", "29", "38", "50", "54", "62", "62red", "102", "103", "104", "17x54", "17x87", "23x23", "29x42", "29x90", "39x90", "39x48", "52x29", "54x29", "60x86", "62x29", "62x100", "102x51", "102x152", "103x164", "d12", "d24", "d58", "pt12", "pt18", "pt24", "pt36"]
+        auto_fit:
+          type: boolean
+          description: >
+            Shrink the font until the text fits a die-cut label's fixed height.
+            Ignored on continuous tape, which grows to fit instead.
+          default: true
         rotate:
           type: integer
           description: Rotation angle in degrees

--- a/src/api/text_controller.py
+++ b/src/api/text_controller.py
@@ -5,6 +5,8 @@ Controller for text printing API endpoints.
 import structlog
 from typing import Dict, Any
 
+from flask import send_file
+
 from services.printer_service import printer_service
 from utils.exceptions import ValidationError, PrinterError, ResourceNotFoundError
 
@@ -54,3 +56,46 @@ def print_text(body: Dict[str, Any]) -> Dict[str, Any]:
     except Exception as e:
         logger.error("Error printing text", error=str(e), exc_info=True)
         raise PrinterError(f"Error printing text: {str(e)}")
+
+
+def preview_text(body: Dict[str, Any]) -> Any:
+    """
+    Render a text label and return the PNG without printing.
+
+    Uses the same code path as print_text, so the preview is the exact bitmap
+    that would be sent to the printer -- including wrapping, font metrics and
+    label width. A client-side approximation cannot stay in sync with Pillow's
+    rendering; this cannot drift because it IS the render.
+
+    Args:
+        body: Dict containing text and render settings.
+
+    Returns:
+        Flask response containing the rendered PNG.
+    """
+    try:
+        logger.info("Processing text preview request")
+
+        text = body.get("text")
+        settings = body.get("settings", {})
+
+        if not text:
+            raise ValidationError("text is required", "text")
+
+        # label_size drives the canvas width; the printer settings are not
+        # needed to render, so preview works before a printer is configured.
+        settings.setdefault("label_size", "62")
+
+        image_path = printer_service._create_text_label(text, settings)
+
+        rotate = settings.get("rotate", 0)
+        if rotate:
+            image_path = printer_service._apply_rotation(image_path, rotate)
+
+        return send_file(image_path, mimetype="image/png")
+    except ValidationError as e:
+        logger.error("Validation error", error=str(e), exc_info=True)
+        raise
+    except Exception as e:
+        logger.error("Error generating preview", error=str(e), exc_info=True)
+        raise

--- a/src/services/printer_service.py
+++ b/src/services/printer_service.py
@@ -385,12 +385,8 @@ class PrinterService:
             if auto_fit and is_die_cut and max_height:
                 line_spacing_est = 5
                 while font_size > 8:
-                    est = 20 + sum(
-                        dummy_draw.textbbox((0, 0), ln, font=font)[3]
-                        - dummy_draw.textbbox((0, 0), ln, font=font)[1]
-                        + line_spacing_est
-                        for ln in wrapped
-                    )
+                    a, d = font.getmetrics()
+                    est = 20 + len(wrapped) * (a + d + line_spacing_est)
                     if est <= max_height:
                         break
                     font_size -= 2
@@ -399,11 +395,17 @@ class PrinterService:
 
             lines = wrapped
 
+            max_ascent, max_descent = font.getmetrics()
+            # Use the font's own line height rather than the ink bbox. bbox
+            # measures only the glyphs present, so a line without descenders
+            # ("FULL WIDTH TEST") measures short -- but draw.text() still
+            # positions from the ascent line and reserves descent space, so the
+            # final line's descenders fell off the bottom of the canvas.
+            line_height = max_ascent + max_descent
+
             for line in lines:
                 bbox = dummy_draw.textbbox((0, 0), line, font=font)
                 line_width = bbox[2] - bbox[0]
-                line_height = bbox[3] - bbox[1]
-                max_ascent, max_descent = font.getmetrics()
                 total_height += line_height + line_spacing
                 line_metrics.append((line, max_ascent, max_descent, line_height, line_width))
             

--- a/src/services/printer_service.py
+++ b/src/services/printer_service.py
@@ -357,7 +357,10 @@ class PrinterService:
             
             # Calculate total height and line metrics
             total_height = 10
-            line_spacing = 5
+            # ascent+descent is the font's full line box and already includes
+            # the gap below the baseline, so no extra leading is needed. (When
+            # line height was measured from the ink bbox this was 5.)
+            line_spacing = 0
             line_metrics = []
             
             font = ImageFont.truetype(self.font_path, font_size)
@@ -383,7 +386,7 @@ class PrinterService:
             wrapped = wrap_all(font)
 
             if auto_fit and is_die_cut and max_height:
-                line_spacing_est = 5
+                line_spacing_est = 0
                 while font_size > 8:
                     a, d = font.getmetrics()
                     est = 20 + len(wrapped) * (a + d + line_spacing_est)

--- a/src/services/printer_service.py
+++ b/src/services/printer_service.py
@@ -16,6 +16,26 @@ from brother_ql.raster import BrotherQLRaster
 from brother_ql.conversion import convert
 from brother_ql.backends import backend_factory, guess_backend
 
+
+def get_label_width(label_size, default=696):
+    """Return the printable width in pixels for a label size identifier.
+
+    brother_ql knows the true printable width of every supported roll, so look
+    it up rather than assuming one. Falls back to `default` (62mm) for unknown
+    or missing identifiers.
+    """
+    if not label_size:
+        return default
+    try:
+        from brother_ql.labels import ALL_LABELS
+        for label in ALL_LABELS:
+            if label.identifier == str(label_size):
+                return label.dots_printable[0]
+    except Exception:
+        pass
+    return default
+
+
 # Import pysnmp for SNMP-based printer communication
 try:
     from pysnmp.hlapi import (
@@ -197,7 +217,7 @@ class PrinterService:
             logger.info("Processing image print request", job_id=job_id, image_path=image_path)
             
             # Resize image to fit label width
-            resized_path = self._resize_image(image_path)
+            resized_path = self._resize_image(image_path, settings.get("label_size"))
             logger.info("Image resized", job_id=job_id, resized_path=resized_path)
             
             # Apply rotation if specified
@@ -268,7 +288,7 @@ class PrinterService:
                 lines.append("".join(current_line))
             
             # Create image
-            width = 696  # Fixed label width
+            width = get_label_width(settings.get("label_size"))
             font_size = int(settings.get("font_size", 50))
             alignment = settings.get("alignment", "left")
             
@@ -316,7 +336,7 @@ class PrinterService:
             logger.error("Error creating text label", error=str(e), exc_info=True)
             raise ImageProcessingError(f"Error creating text label: {str(e)}")
     
-    def _resize_image(self, image_path: str) -> str:
+    def _resize_image(self, image_path: str, label_size: str = None) -> str:
         """
         Resize an image to fit the label width.
         
@@ -330,7 +350,7 @@ class PrinterService:
             ImageProcessingError: If there's an error resizing the image.
         """
         try:
-            max_width = 696  # Fixed label width
+            max_width = get_label_width(label_size)
             
             with Image.open(image_path) as img:
                 # Calculate new dimensions
@@ -707,7 +727,7 @@ class PrinterService:
                 # Calculate dimensions for the combined image
                 # Text takes 2/3, QR code takes 1/3
                 padding = 20
-                total_width = max(qr_width + max_text_width + padding * 3, 696)  # Ensure minimum width
+                total_width = max(qr_width + max_text_width + padding * 3, get_label_width(settings.get("label_size")))
                 text_area_width = int(total_width * 2/3) - padding * 2
                 qr_area_width = total_width - text_area_width - padding * 3
                 

--- a/src/services/printer_service.py
+++ b/src/services/printer_service.py
@@ -411,6 +411,18 @@ class PrinterService:
             
             # Create the actual image
             total_height += 10
+
+            # A die-cut label is a fixed physical size, so the canvas is pinned
+            # to its real height regardless of content. Continuous tape has no
+            # such bound and grows to whatever the text needs.
+            #
+            # With auto_fit on, the font was already stepped down so the text
+            # fits. With it off, the user has asked to keep their font size, so
+            # overflow is clipped -- but the canvas still matches the label,
+            # rather than silently growing into a size the printer cannot cut.
+            if is_die_cut and max_height:
+                total_height = max_height
+
             image = Image.new("RGB", (width, total_height), "white")
             draw = ImageDraw.Draw(image)
             

--- a/src/services/printer_service.py
+++ b/src/services/printer_service.py
@@ -275,15 +275,20 @@ class PrinterService:
             
             logger.info("Processing image print request", job_id=job_id, image_path=image_path)
             
-            # Resize image to fit label width
-            resized_path = self._resize_image(image_path, settings.get("label_size"))
-            logger.info("Image resized", job_id=job_id, resized_path=resized_path)
-            
-            # Apply rotation if specified
+            # Rotate BEFORE resizing. Resizing fits the image to the label
+            # width; rotating afterwards swaps the axes, leaving the image
+            # narrower than the label so the printer scales it back up -- which
+            # visually undoes the rotation. Rotating first means the resize
+            # fits whichever edge is actually going across the tape.
             rotate = settings.get("rotate", 0)
+            source_path = image_path
             if rotate != 0:
-                resized_path = self._apply_rotation(resized_path, rotate)
+                source_path = self._apply_rotation(image_path, rotate)
                 logger.info("Rotation applied", job_id=job_id, rotate=rotate)
+
+            # Resize image to fit label width
+            resized_path = self._resize_image(source_path, settings.get("label_size"))
+            logger.info("Image resized", job_id=job_id, resized_path=resized_path)
             
             # Send to printer
             self._send_to_printer(resized_path, settings)

--- a/src/services/printer_service.py
+++ b/src/services/printer_service.py
@@ -553,11 +553,15 @@ class PrinterService:
             qlr.exception_on_warning = True
             
             # Convert image to printer instructions
+            # rotate=0, NOT the caller's value: rotation is already applied to
+            # the image by _apply_rotation before it gets here. Passing it again
+            # makes brother_ql rotate a second time, undoing the first and
+            # producing a label at the original orientation and size.
             instructions = convert(
                 qlr=qlr,
                 images=[image_path],
                 label=label_size,
-                rotate=rotate,
+                rotate=0,
                 threshold=threshold,
                 dither=dither,
                 compress=compress,

--- a/src/services/printer_service.py
+++ b/src/services/printer_service.py
@@ -17,6 +17,65 @@ from brother_ql.conversion import convert
 from brother_ql.backends import backend_factory, guess_backend
 
 
+def get_label_height(label_size):
+    """Return (height_px, is_die_cut) for a label identifier.
+
+    Continuous ("endless") rolls report height 0 -- their length is unlimited,
+    so a label can grow downward. Die-cut labels have a fixed height that the
+    content must fit inside.
+    """
+    if not label_size:
+        return (0, False)
+    try:
+        from brother_ql.labels import ALL_LABELS, FormFactor
+        for label in ALL_LABELS:
+            if label.identifier == str(label_size):
+                die_cut = label.form_factor in (
+                    FormFactor.DIE_CUT, FormFactor.ROUND_DIE_CUT)
+                return (label.dots_printable[1], die_cut)
+    except Exception:
+        pass
+    return (0, False)
+
+
+def wrap_line_to_width(draw, text, font, max_width):
+    """Split `text` into lines that each fit within `max_width` pixels.
+
+    Wraps on word boundaries; a single word longer than the label is broken
+    character-by-character so it is never silently cropped.
+    """
+    if not text:
+        return [""]
+    if draw.textbbox((0, 0), text, font=font)[2] <= max_width:
+        return [text]
+
+    lines, current = [], ""
+    for word in text.split(" "):
+        candidate = word if not current else current + " " + word
+        if draw.textbbox((0, 0), candidate, font=font)[2] <= max_width:
+            current = candidate
+            continue
+        if current:
+            lines.append(current)
+            current = ""
+        # A word too wide even on its own: break it up.
+        if draw.textbbox((0, 0), word, font=font)[2] > max_width:
+            piece = ""
+            for ch in word:
+                if draw.textbbox((0, 0), piece + ch, font=font)[2] <= max_width:
+                    piece += ch
+                else:
+                    if piece:
+                        lines.append(piece)
+                    piece = ch
+            current = piece
+        else:
+            current = word
+    if current:
+        lines.append(current)
+    return lines or [""]
+
+
 def get_label_width(label_size, default=696):
     """Return the printable width in pixels for a label size identifier.
 
@@ -301,8 +360,46 @@ class PrinterService:
             line_spacing = 5
             line_metrics = []
             
+            font = ImageFont.truetype(self.font_path, font_size)
+
+            # Wrap to the label width. Continuous tape has effectively unlimited
+            # length, so the canvas grows downward to fit rather than the text
+            # being cropped at the edge.
+            text_area = width - 20  # 10px margin either side
+
+            def wrap_all(f):
+                out = []
+                for line in lines:
+                    out.extend(wrap_line_to_width(dummy_draw, line, f, text_area))
+                return out
+
+            # auto_fit shrinks the font until the wrapped text fits the label's
+            # fixed height. It only applies to die-cut labels -- on continuous
+            # tape there is nothing to shrink to fit, so the setting is ignored
+            # and the label simply grows.
+            auto_fit = settings.get("auto_fit", True)
+            max_height, is_die_cut = get_label_height(settings.get("label_size"))
+
+            wrapped = wrap_all(font)
+
+            if auto_fit and is_die_cut and max_height:
+                line_spacing_est = 5
+                while font_size > 8:
+                    est = 20 + sum(
+                        dummy_draw.textbbox((0, 0), ln, font=font)[3]
+                        - dummy_draw.textbbox((0, 0), ln, font=font)[1]
+                        + line_spacing_est
+                        for ln in wrapped
+                    )
+                    if est <= max_height:
+                        break
+                    font_size -= 2
+                    font = ImageFont.truetype(self.font_path, font_size)
+                    wrapped = wrap_all(font)
+
+            lines = wrapped
+
             for line in lines:
-                font = ImageFont.truetype(self.font_path, font_size)
                 bbox = dummy_draw.textbbox((0, 0), line, font=font)
                 line_width = bbox[2] - bbox[0]
                 line_height = bbox[3] - bbox[1]

--- a/src/static/index.html
+++ b/src/static/index.html
@@ -114,7 +114,21 @@
                                             </div>
                                         </div>
                                     </div>
-                                    
+
+                                    <div class="row g-3 mt-0">
+                                        <div class="col-12">
+                                            <div class="form-check form-switch">
+                                                <input class="form-check-input" type="checkbox" id="text-auto-fit" checked>
+                                                <label class="form-check-label" for="text-auto-fit">
+                                                    Auto-fit font to label
+                                                    <small class="text-muted d-block">
+                                                        Shrinks the text to fit die-cut labels. Continuous tape grows instead, so this has no effect there.
+                                                    </small>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div>
+
                                     <button type="submit" class="btn btn-primary w-100">
                                         <i class="bi bi-printer-fill me-2"></i>Print Text
                                     </button>

--- a/src/static/js/api.js
+++ b/src/static/js/api.js
@@ -250,7 +250,8 @@ async function handleTextPrint(event) {
                     rotate: parseInt(rotate),
                     threshold: parseFloat(threshold),
                     dither: dither,
-                    red: red
+                    red: red,
+                    auto_fit: (document.getElementById('text-auto-fit') || {}).checked !== false
                 }
             })
         });

--- a/src/static/js/core.js
+++ b/src/static/js/core.js
@@ -103,8 +103,10 @@ function setupEventListeners() {
         
         if (textInput && textFontSize && textAlignment) {
             const labelSizeEl = document.getElementById('label-size');
-            [textInput, textFontSize, textAlignment, labelSizeEl].filter(Boolean).forEach(el => {
+            const autoFitEl = document.getElementById('text-auto-fit');
+            [textInput, textFontSize, textAlignment, labelSizeEl, autoFitEl].filter(Boolean).forEach(el => {
                 el.addEventListener('input', updateTextPreview);
+                el.addEventListener('change', updateTextPreview);
             });
         }
     }

--- a/src/static/js/core.js
+++ b/src/static/js/core.js
@@ -102,7 +102,8 @@ function setupEventListeners() {
         const textAlignment = document.getElementById('text-alignment');
         
         if (textInput && textFontSize && textAlignment) {
-            [textInput, textFontSize, textAlignment].forEach(el => {
+            const labelSizeEl = document.getElementById('label-size');
+            [textInput, textFontSize, textAlignment, labelSizeEl].filter(Boolean).forEach(el => {
                 el.addEventListener('input', updateTextPreview);
             });
         }

--- a/src/static/js/preview.js
+++ b/src/static/js/preview.js
@@ -102,6 +102,7 @@ function updateTextPreview() {
             label_size: (document.getElementById('label-size') || {}).value || '62',
             font_size: parseInt(textFontSize.value, 10) || 50,
             alignment: textAlignment.value,
+            auto_fit: (document.getElementById('text-auto-fit') || {}).checked !== false,
         };
 
         // Ask the server for the actual label bitmap rather than approximating

--- a/src/static/js/preview.js
+++ b/src/static/js/preview.js
@@ -73,45 +73,67 @@ function hideOtherPreviews(exceptId) {
 /**
  * Update text preview
  */
+let _previewTimer = null;
+
 function updateTextPreview() {
     const textInput = document.getElementById('text-input');
     const textFontSize = document.getElementById('text-font-size');
     const textAlignment = document.getElementById('text-alignment');
     const previewText = document.getElementById('preview-text');
     const previewPlaceholder = document.getElementById('preview-placeholder');
-    
-    if (textInput && textFontSize && textAlignment && previewText) {
-        const text = textInput.value.trim();
-        const fontSize = textFontSize.value;
-        const alignment = textAlignment.value;
-        
-        // Show or hide elements based on content
-        if (text) {
-            // Format text with HTML
-            const formattedText = text
-                .replace(/\n/g, '<br>')
-                .replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>')
-                .replace(/\*(.*?)\*/g, '<em>$1</em>');
-            
-            // Update preview
-            previewText.innerHTML = formattedText;
-            previewText.style.fontSize = `${fontSize}px`;
-            previewText.style.textAlign = alignment;
-            previewText.classList.remove('d-none');
-            
-            // Hide placeholder and other previews
-            if (previewPlaceholder) previewPlaceholder.classList.add('d-none');
-            hideOtherPreviews('preview-text');
-        } else {
-            // Hide text preview if empty
-            previewText.classList.add('d-none');
-            
-            // Show placeholder if all previews are empty
-            if (areAllPreviewsEmpty() && previewPlaceholder) {
-                previewPlaceholder.classList.remove('d-none');
-            }
+
+    if (!(textInput && textFontSize && textAlignment && previewText)) return;
+
+    const text = textInput.value.trim();
+
+    if (!text) {
+        previewText.classList.add('d-none');
+        previewText.innerHTML = '';
+        if (areAllPreviewsEmpty() && previewPlaceholder) {
+            previewPlaceholder.classList.remove('d-none');
         }
+        return;
     }
+
+    // Debounce: rendering happens server-side, so avoid a request per keystroke.
+    if (_previewTimer) clearTimeout(_previewTimer);
+    _previewTimer = setTimeout(() => {
+        const settings = {
+            label_size: (document.getElementById('label-size') || {}).value || '62',
+            font_size: parseInt(textFontSize.value, 10) || 50,
+            alignment: textAlignment.value,
+        };
+
+        // Ask the server for the actual label bitmap rather than approximating
+        // it with CSS. Browser font metrics and wrapping do not match Pillow's,
+        // so a styled-DOM preview disagrees with what actually prints.
+        fetch('api/v1/text/preview', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ text: text, settings: settings }),
+        })
+            .then(r => {
+                if (!r.ok) throw new Error('preview failed: ' + r.status);
+                return r.blob();
+            })
+            .then(blob => {
+                const url = URL.createObjectURL(blob);
+                previewText.innerHTML =
+                    '<img src="' + url + '" alt="Label preview" ' +
+                    'style="max-width:100%;height:auto;image-rendering:pixelated;">';
+                previewText.classList.remove('d-none');
+                if (previewPlaceholder) previewPlaceholder.classList.add('d-none');
+                hideOtherPreviews('preview-text');
+            })
+            .catch(err => {
+                console.error('Preview error:', err);
+                // Fall back to plain text so the field still shows something.
+                previewText.textContent = text;
+                previewText.classList.remove('d-none');
+                if (previewPlaceholder) previewPlaceholder.classList.add('d-none');
+                hideOtherPreviews('preview-text');
+            });
+    }, 300);
 }
 
 /**


### PR DESCRIPTION
The image builders hardcode `width = 696`, which is the printable width of 62mm tape. Any narrower roll is rendered too wide and the printer crops it: on 50mm tape (554px printable) 142px is lost, roughly half an inch split across both ends, so text is clipped at the start and end.

The symptom is confusing because `label_size` is accepted and passed to brother_ql for the print itself -- it just never reaches the image builder, so changing it appears to do nothing and every label comes out the same size.

brother_ql already knows the true printable width of every supported roll, so look it up from ALL_LABELS rather than assuming one. Unknown or missing identifiers fall back to 696, so existing setups are unaffected.

Fixes three sites: text labels, image resizing, and the QR+text combined image. _resize_image gains an optional label_size parameter.

Verified against a QL-800 with DK-2223 (50mm): 50 -> 554, 62 -> 696, 29 -> 306, unknown -> 696.